### PR TITLE
Temp hardcode binary name and remove quality scan from main push

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,10 +12,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]  
+    branches: [ "main" ]
 
 jobs:
   analyze:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,6 @@ jobs:
       matrix:
         goosarch:
           - 'linux/amd64'
-          - 'darwin/amd64'
-          - 'windows/amd64'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -57,6 +55,7 @@ jobs:
         with:
           body_path: ".github/RELEASE-TEMPLATE.md"
           draft: true
-          files: ${{env.BINARY_NAME}}
+          files: bgit
+          #files: ${{env.BINARY_NAME}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- for the economy, quality scan workflow will run only on pull requests
- temporarily hardcode the binary name to `bgit` when new releases are created